### PR TITLE
gx: update go-testutil

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.16: QmRCK8YSxVuHayP3s9bpLRB5Ty7tsjAfgf16aJCNSuV7kS
+0.1.17: QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: go
 
 go:
-    - 1.7
+    - 1.8
 
 install: true
 

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "Qmeqtv7ASvepCpUDxysK2oP1urtEr5eMNMxbhTJYJziAGo",
+      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
       "name": "go-libp2p-host",
-      "version": "1.3.17"
+      "version": "1.3.18"
     },
     {
       "author": "whyrusleeping",
@@ -38,9 +38,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmZg566m6GTANKnweD63nLao2J5qgFVSKscHqrNyVUzwDA",
+      "hash": "QmdjeSxRchVsQ2ftrZyvVmFqoJ1QbJZ2PgugBsZ58TZZqQ",
       "name": "go-libp2p-connmgr",
-      "version": "0.1.1"
+      "version": "0.1.2"
     },
     {
       "author": "multiformats",
@@ -66,6 +66,6 @@
   "license": "",
   "name": "go-libp2p-blankhost",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.16"
+  "version": "0.1.17"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-conn/pull/12
- https://github.com/libp2p/go-libp2p-connmgr/pull/3
- https://github.com/libp2p/go-libp2p-host/pull/6
- https://github.com/libp2p/go-libp2p-swarm/pull/28
- https://github.com/libp2p/go-libp2p-netutil/pull/8


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace