### PR TITLE
gx: update go-cid, go-multibase, base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.1.17: QmYCDYphqhKPAfyyLQykUMYikhV9a4NhxgQarwNsbQyctu
+0.1.18: QmSmgF5Nnmf1Ygkv96xCmUdPk4QPx3JotTA7sqwXpoxCV2

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmW8Rgju5JrSMHP7RDNdiwwXyenRqAbtSaPfdQKQC7ZdH6",
+      "hash": "QmUwW8jMQDxXhLD2j4EfWqLEMX3MsvyWcWGvJPVDh1aTmu",
       "name": "go-libp2p-host",
-      "version": "1.3.18"
+      "version": "1.3.19"
     },
     {
       "author": "whyrusleeping",
@@ -38,9 +38,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmdjeSxRchVsQ2ftrZyvVmFqoJ1QbJZ2PgugBsZ58TZZqQ",
+      "hash": "QmTuwwqGf4NH2Jj3opKtaKx45ge4RiXSCtvUkb7a4gk2ua",
       "name": "go-libp2p-connmgr",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "author": "multiformats",
@@ -66,6 +66,6 @@
   "license": "",
   "name": "go-libp2p-blankhost",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.1.17"
+  "version": "0.1.18"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-testutil/pull/12
- https://github.com/libp2p/go-libp2p-conn/pull/15
- https://github.com/libp2p/go-libp2p-connmgr/pull/5
- https://github.com/libp2p/go-libp2p-host/pull/8
- https://github.com/libp2p/go-libp2p-swarm/pull/32
- https://github.com/libp2p/go-libp2p-netutil/pull/11


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace