### PR TITLE
gx: update go-libp2p-peerstore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.2.3: QmYmhgAcvmDGXct1qBvc1kz9BxQSit1XBrTeiGZp2FvRyn
+0.2.4: QmP4BoRH7qHbyVAjpXqZqXm3X2sMWokgACF9m5RXBWLDkq

--- a/package.json
+++ b/package.json
@@ -9,21 +9,21 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmP46LGWhzVZTMmt5akNNLfoV8qL4h5wTwmzQxLyDafggd",
+      "hash": "QmbEk4hyXjohArLiff8inoGsoywzfPD71SqD4qHZBiWQyr",
       "name": "go-libp2p-host",
-      "version": "2.1.3"
+      "version": "2.1.4"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmU4vCDZTPLDqSDKguWbHCiUe46mZUtmM2g2suBZ9NE8ko",
+      "hash": "Qmegn1aFLQmbCg4xurYgLug9TJ3rTVFjJ3L5fD3m9m4qMf",
       "name": "go-libp2p-net",
-      "version": "2.0.3"
+      "version": "2.0.4"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmYijbtjCxFEjSXaudaQAUz3LN5VKLssm8WCUsRoqzXmQR",
+      "hash": "QmQoXyRXtorcAtWwnud9HBod3vjPC8vTu1gJnsg9PLwuiT",
       "name": "go-libp2p-peerstore",
-      "version": "1.4.10"
+      "version": "1.4.11"
     },
     {
       "hash": "QmSpJByNKFX1sCsHBEp3R73FL4NF6FnQTEGyNAXHm2GS52",
@@ -60,6 +60,6 @@
   "license": "",
   "name": "go-libp2p-blankhost",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.2.3"
+  "version": "0.2.4"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-net/pull/18
- https://github.com/libp2p/go-libp2p-metrics/pull/11
- https://github.com/libp2p/go-libp2p-interface-connmgr/pull/4
- https://github.com/libp2p/go-libp2p-host/pull/12
- https://github.com/libp2p/go-libp2p-swarm/pull/53
- https://github.com/libp2p/go-libp2p-netutil/pull/18


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace