### PR TITLE
subscribe connmgr to net notifications

### DIFF
--- a/blank.go
+++ b/blank.go
@@ -63,6 +63,9 @@ func NewBlankHost(n network.Network, options ...Option) *BlankHost {
 		eventbus: eventbus.NewBus(),
 	}
 
+	// subscribe the connection manager to network notifications (has no effect with NullConnMgr)
+	n.Notify(bh.cmgr.Notifee())
+
 	var err error
 	if bh.emitters.evtLocalProtocolsUpdated, err = bh.eventbus.Emitter(&event.EvtLocalProtocolsUpdated{}); err != nil {
 		return nil


### PR DESCRIPTION
@vyzo I didn't realize when making #44 that the connection manager needs to be subscribed to the network notifications. `BasicHost` does it for us, but now that we may have a real connmgr we should do it here also.